### PR TITLE
Feature/setup rails admin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,8 @@ gem "cancancan"
 gem "kaminari"
 gem "ransack" # Search engine for Active Record
 gem "shrine" # File attachment library for Ruby applications
+gem 'rails_admin', '~> 3.0'
+gem "sassc-rails" # Sass compiler for Rails
 
 gem "stringio", "3.0.4"
 
@@ -71,3 +73,4 @@ group :test do
   gem "capybara"
   gem "selenium-webdriver"
 end
+gem "sassc-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,6 +50,10 @@ GEM
       globalid (>= 0.3.6)
     activemodel (7.2.2.1)
       activesupport (= 7.2.2.1)
+    activemodel-serializers-xml (1.0.3)
+      activemodel (>= 5.0.0.a)
+      activesupport (>= 5.0.0.a)
+      builder (~> 3.1)
     activerecord (7.2.2.1)
       activemodel (= 7.2.2.1)
       activesupport (= 7.2.2.1)
@@ -111,6 +115,7 @@ GEM
     connection_pool (2.5.0)
     content_disposition (1.0.0)
     crass (1.0.6)
+    csv (3.3.4)
     date (3.4.1)
     devise (4.9.4)
       bcrypt (~> 3.0)
@@ -129,6 +134,7 @@ GEM
     factory_bot_rails (6.4.4)
       factory_bot (~> 6.5)
       railties (>= 5.0.0)
+    ffi (1.17.2-x86_64-linux-gnu)
     globalid (1.2.1)
       activesupport (>= 6.1)
     i18n (1.14.7)
@@ -175,6 +181,7 @@ GEM
     mini_mime (1.1.5)
     minitest (5.25.5)
     msgpack (1.8.0)
+    nested_form (0.3.2)
     net-imap (0.5.6)
       date
       net-protocol
@@ -236,6 +243,13 @@ GEM
     rails-html-sanitizer (1.6.2)
       loofah (~> 2.21)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
+    rails_admin (3.3.0)
+      activemodel-serializers-xml (>= 1.0)
+      csv
+      kaminari (>= 0.14, < 2.0)
+      nested_form (~> 0.3)
+      rails (>= 6.0, < 9)
+      turbo-rails (>= 1.0, < 3)
     railties (7.2.2.1)
       actionpack (= 7.2.2.1)
       activesupport (= 7.2.2.1)
@@ -328,6 +342,14 @@ GEM
       rubocop-rspec (~> 3.5)
     ruby-progressbar (1.13.0)
     rubyzip (2.4.1)
+    sassc (2.4.0)
+      ffi (~> 1.9)
+    sassc-rails (2.1.2)
+      railties (>= 4.0.0)
+      sassc (>= 2.0)
+      sprockets (> 3.0)
+      sprockets-rails
+      tilt
     securerandom (0.4.1)
     selenium-webdriver (4.31.0)
       base64 (~> 0.2)
@@ -354,7 +376,11 @@ GEM
       sprockets (>= 3.0.0)
     stringio (3.0.4)
     thor (1.3.2)
+    tilt (2.6.0)
     timeout (0.4.3)
+    turbo-rails (2.0.13)
+      actionpack (>= 7.1.0)
+      railties (>= 7.1.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (3.1.4)
@@ -396,12 +422,14 @@ DEPENDENCIES
   postgresql
   puma (>= 5.0)
   rails (~> 7.2.2)
+  rails_admin (~> 3.0)
   ransack
   rspec-rails
   rubocop
   rubocop-capybara
   rubocop-discourse
   rubocop-rails-omakase
+  sassc-rails
   selenium-webdriver
   shrine
   simplecov

--- a/app/models/advertisement.rb
+++ b/app/models/advertisement.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: advertisements
+#
+#  id         :bigint           not null, primary key
+#  title      :string(255)
+#  link_url   :string(255)
+#  image_url  :string(255)
+#  active     :boolean          default(FALSE)
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+class Advertisement < ApplicationRecord
+  validates :title, presence: true
+  validates :link_url, presence: true
+  validates :image_url, presence: false
+  validates :active, inclusion: { in: [true, false] }
+  # has_one_attached :image
+  attr_accessor :tag_string
+end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,0 +1,2 @@
+class Tag < ApplicationRecord
+end

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -1,0 +1,42 @@
+RailsAdmin.config do |config|
+  config.asset_source = :sprockets
+
+  ### Popular gems integration
+
+  ## == Devise ==
+  # config.authenticate_with do
+  #   warden.authenticate! scope: :user
+  # end
+  # config.current_user_method(&:current_user)
+
+  ## == CancanCan ==
+  # config.authorize_with :cancancan
+
+  ## == Pundit ==
+  # config.authorize_with :pundit
+
+  ## == PaperTrail ==
+  # config.audit_with :paper_trail, 'User', 'PaperTrail::Version' # PaperTrail >= 3.0.0
+
+  ### More at https://github.com/railsadminteam/rails_admin/wiki/Base-configuration
+
+  ## == Gravatar integration ==
+  ## To disable Gravatar integration in Navigation Bar set to false
+  # config.show_gravatar = true
+
+  config.actions do
+    dashboard                     # mandatory
+    index                         # mandatory
+    new
+    export
+    bulk_delete
+    show
+    edit
+    delete
+    show_in_app
+
+    ## With an audit adapter, you can add:
+    # history_index
+    # history_show
+  end
+end

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -39,4 +39,16 @@ RailsAdmin.config do |config|
     # history_index
     # history_show
   end
+
+  config.model 'Advertisement' do
+    edit do
+      field :title
+      field :link_url
+      field :image_url
+      field :tag_string do
+        label 'Tags (comma separated)'
+        help 'Enter tags separated by commas'
+      end
+    end
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  mount RailsAdmin::Engine => '/admin', as: 'rails_admin'
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/db/migrate/20250511234935_create_tags.rb
+++ b/db/migrate/20250511234935_create_tags.rb
@@ -1,0 +1,9 @@
+class CreateTags < ActiveRecord::Migration[7.2]
+  def change
+    create_table :tags do |t|
+      t.string :name, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250513001426_create_advertisements.rb
+++ b/db/migrate/20250513001426_create_advertisements.rb
@@ -1,0 +1,13 @@
+class CreateAdvertisements < ActiveRecord::Migration[7.2]
+  def change
+    create_table :advertisements do |t|
+      t.string :title, null: false
+      t.string :link_url, null: false
+      t.string :image_url
+      t.boolean :active, default: false
+      t.string :tags, array: true, default: []
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,32 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[7.2].define(version: 2025_05_13_001426) do
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "advertisements", force: :cascade do |t|
+    t.string "title", null: false
+    t.string "link_url", null: false
+    t.string "image_url"
+    t.boolean "active", default: false
+    t.string "tags", default: [], array: true
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "tags", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+end

--- a/spec/factories/advertisements.rb
+++ b/spec/factories/advertisements.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :advertisement do
+    title { "MyString" }
+    link_url { "MyString" }
+    image_url { "MyString" }
+    active { false }
+    tags { "MyString" }
+  end
+end

--- a/spec/factories/tags.rb
+++ b/spec/factories/tags.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :tag do
+    name { "MyString" }
+  end
+end

--- a/spec/models/advertisement_spec.rb
+++ b/spec/models/advertisement_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Advertisement, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Tag, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
https://github.com/railsadminteam/rails_admin

---

## 🔧 1. モデルに仮想カラムを追加

PostgreSQLの `string[]` に対応するため、モデルに **フォーム入力用の仮想属性** を定義します。

```ruby
class Advertisement < ApplicationRecord
  # tags: string[] column

  # 仮想属性
  def tag_string
    tags&.join(', ')
  end

  def tag_string=(value)
    self.tags = value.split(',').map(&:strip).reject(&:blank?)
  end
end
```

これにより、フォームでは `tag_string` を編集して、内部的には `tags` 配列を操作できます。

---

## 🛠 2. RailsAdminで `tag_string` を使うように設定

RailsAdminの設定で、`tags` ではなく `tag_string` をフォームフィールドとして使うように指定します。

```ruby
RailsAdmin.config do |config|
  config.model 'Advertisement' do
    edit do
      field :title
      field :url
      field :image_url
      field :tag_string do
        label 'Tags (comma separated)'
        help 'Enter tags separated by commas'
      end
    end
  end
end
```

---

## ✅ 補足

* `tag_string` を `formtastic` 風に処理することで、RailsAdminの型制限を回避しています。
* 保存時に余計な空白や空要素が混ざらないように `.map(&:strip).reject(&:blank?)` でクレンジングしています。

---

この方法であれば、RailsAdminの制限を気にせず、PostgreSQLの `string[]` 型を活かせます。さらにUI上もシンプルで、使う人にも優しい設計です。

もしタグに補完機能を付けたければ、あとから `Tagify` や `Selectize.js` を上書きで噛ませることもできますよ。必要ならその方法もお教えします。
